### PR TITLE
Initial commit

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer:  echo -n 'bWljaGFsQGdldGNyeXN0LmFs'     | base64 -d
+# Contributor: echo -n 'bWF0dEBnZXRjcnlzdC5hbA=='     | base64 -d
+# Contributor: echo -n 'cmNhbmRhdUBnZXRjcnlzdC5hbA==' | base64 -d
+
+pkgname=crystal-branding
+_pkgname=branding
+pkgver=2022.10.08
+pkgrel=1
+pkgdesc='Crystal Linux branding'
+arch=('any')
+license=('GPL3')
+url="https://github.com/crystal-linux/${_pkgname}"
+install="${pkgname}.install"
+source=("${pkgname}-${pkgver}::${url}/archive/${pkgver}.tar.gz"
+	"os-release_crystal"
+	"issue_crystal")
+sha256sums=('8e39286724310ca566fc02908e83456bd15d4fa102addd12f8c9c8fad8eeddd4'
+	    '7b284f8f71a0cc9943b0b68dec694dc6f314ec779c0dca23c84d02d271a02725'
+	    'af9064feb584990461d65dc4810aec4395754924b3fea564b84b8d76d47538f6')
+
+package () {
+    cd "${srcdir}/${_pkgname}-${pkgver}"
+    install -Dm 644 in-system/crystal-os-logo.png "${pkgdir}/usr/share/pixmaps/crystal-os-logo.png"
+    install -Dm 644 ../os-release_crystal "${pkgdir}/etc/os-release_crystal"
+    install -Dm 644 ../issue_crystal "${pkgdir}/etc/issue_crystal"
+}

--- a/crystal-branding.install
+++ b/crystal-branding.install
@@ -1,0 +1,9 @@
+post_install() {
+	mv -f etc/os-release_crystal etc/os-release
+	mv -f etc/issue_crystal etc/issue
+}
+
+post_upgrade() {
+	mv -f etc/os-release_crystal etc/os-release
+        mv -f etc/issue_crystal etc/issue
+}

--- a/issue_crystal
+++ b/issue_crystal
@@ -1,0 +1,1 @@
+Crystal \r (\l)

--- a/os-release_crystal
+++ b/os-release_crystal
@@ -1,0 +1,7 @@
+NAME="Crystal Linux"
+PRETTY_NAME="Crystal Linux"
+ID=crystal
+BUILD_ID=rolling
+HOME_URL="https://getcryst.al"
+LOGO=crystal-os-logo
+ANSI_COLOR="0;35"


### PR DESCRIPTION
Hi team,

I suggested dropping the [crystal's filesystem package](https://github.com/crystal-linux-packages/filesystem) in favor of a package that only installs specific Crystal stuff, in order to let Arch handle the `filesystem` stuffs.
The reasons of this suggestion are basically the same as the ones I gave in favor of [dropping the crystal's base package](https://github.com/crystal-linux-packages/crystal-core/pull/1).

Only packaging our stuff will be much easier to maintain and way more "elegant" in my opinion.

This package basically replaces Arch's `/etc/os-release` and `/etc/issue` by the Crystal's ones and pulls the Crystal logo from the `branding` repo (instead of packaging the whole `filesystem` package members).

Just like the Crystal's base package replacement, that would involve removing the [crystal's filesystem package](https://github.com/crystal-linux-packages/filesystem) from both GitHub and Crystal's repos in order to install the regular Arch's `filesystem` package instead.

What do you think?