### PR TITLE
Moved the GRUB_DISTRIBUTOR change from to 'crystal-branding'

### DIFF
--- a/crystal-branding.install
+++ b/crystal-branding.install
@@ -1,9 +1,13 @@
 post_install() {
 	mv -f etc/os-release_crystal etc/os-release
 	mv -f etc/issue_crystal etc/issue
+        sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
+        grub-mkconfig -o /boot/grub/grub.cfg
 }
 
 post_upgrade() {
 	mv -f etc/os-release_crystal etc/os-release
         mv -f etc/issue_crystal etc/issue
+        sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
+        grub-mkconfig -o /boot/grub/grub.cfg
 }


### PR DESCRIPTION
Hi,

As seen together [here](https://github.com/crystal-linux-packages/grub-theme/pull/1#discussion_r994645651), I moved the change that set the `GRUB_DISTRIBUTOR` var in this package of the `grub-theme` one.

As the part that concerns grub is only in the post install hook we don't necessarily need to make this package depends on grub, but we'll have to make sure that `grub` will be installed before `crystal-branding` in `jade/tourmaline`, otherwise people won't get the `GRUB_DISTRIBUTOR` var set correctly (already raised that on the Discord).