### PR TITLE
Added a condition to check if the grub file exists before running grub stuff

### DIFF
--- a/crystal-branding.install
+++ b/crystal-branding.install
@@ -1,13 +1,19 @@
 post_install() {
 	mv -f etc/os-release_crystal etc/os-release
 	mv -f etc/issue_crystal etc/issue
-        sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
-        grub-mkconfig -o /boot/grub/grub.cfg
+	        
+	if [ -f /etc/default/grub ]; then
+		sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
+		grub-mkconfig -o /boot/grub/grub.cfg
+	fi
 }
 
 post_upgrade() {
 	mv -f etc/os-release_crystal etc/os-release
         mv -f etc/issue_crystal etc/issue
-        sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
-        grub-mkconfig -o /boot/grub/grub.cfg
+        
+	if [ -f /etc/default/grub ]; then
+		sed -i s/GRUB_DISTRIBUTOR=\"Arch\"/GRUB_DISTRIBUTOR=\"Crystal\"/g etc/default/grub
+		grub-mkconfig -o /boot/grub/grub.cfg
+	fi
 }


### PR DESCRIPTION
Hi,

Adding of a condition to check if the `/etc/grub/default` file exists (so basically checking that `grub` is installed) before running grub stuffs in the post install hook to avoid a potential unnecessary error when the post install hook is being run without `grub` installed on the machine.
